### PR TITLE
Ignore .tmp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.tmp


### PR DESCRIPTION
Added  to . This directory is often used by temporary files generated by build tools and IDEs. Ignoring it prevents unnecessary files from being tracked in the repository, keeping the working directory clean and reducing the size of the repository.